### PR TITLE
fix key value of config dict loaded from yaml file at sweep

### DIFF
--- a/code/sweep.py
+++ b/code/sweep.py
@@ -437,7 +437,7 @@ if __name__ == "__main__":
     ver = set_version()
     with open("./config.yaml", "r") as f:
         config_dict = yaml.load(f, Loader=yaml.FullLoader)
-    project_name = config_dict["meta_args"]["project_name"]
+    project_name = config_dict["meta_args"]["project"]
     entity_name = config_dict["meta_args"]["entity_name"]
     display_name = config_dict["meta_args"]["display_name"]
 


### PR DESCRIPTION
config.yaml 데이터를 파싱하여 딕셔너리 데이터를 만들 때, 
키 이름에 `project`가 아닌 `project_name`으로 잘 못 입력된 것으로 확인하고 수정하였습니다.
확인 부탁드립니다.